### PR TITLE
[Draft] Add three sli based metrics in test script

### DIFF
--- a/data_fetching.py
+++ b/data_fetching.py
@@ -22,7 +22,7 @@ database_urls = {
 
 
 def fetch_auctions_from_db(start_id: int, end_id: int) -> list[list[Solution]]:
-    engine = create_engine("postgresql+psycopg://" + database_urls["prod"], echo=True)
+    engine = create_engine("postgresql+psycopg://" + database_urls["prod"])
 
     query = text(
         f"""with trade_data as (select ps.*,

--- a/data_fetching.py
+++ b/data_fetching.py
@@ -104,8 +104,9 @@ from trade_data_with_prices"""
                 order_uid: str = trade_data["order_uid"]
                 sell_token = trade_data["sell_token"]
                 buy_token = trade_data["buy_token"]
+                volume = compute_volume(trade_data)
                 score = compute_score(trade_data)
-                trades.append(Trade(order_uid, sell_token, buy_token, score))
+                trades.append(Trade(order_uid, sell_token, buy_token, volume, score))
             solution = Solution(
                 id=str(solution_uid) + "-" + solver,
                 solver=solver,
@@ -128,6 +129,19 @@ def fetch_auctions(auction_start, auction_end):
             pickle.dump(solutions_batch, handle, protocol=-1)
     return solutions_batch
 
+def compute_volume(trade_data) -> int:
+    executed_sell = int(trade_data["executed_sell_amount"])
+    executed_buy = int(trade_data["executed_buy_amount"])
+    buy_price = Fraction(int(trade_data["buy_token_price"]), 10**18)
+    if trade_data["kind"] == "sell":
+        executed_buy = int(trade_data["executed_buy_amount"])
+        buy_price = Fraction(int(trade_data["buy_token_price"]), 10**18)
+        volume = math.floor(executed_buy * buy_price)
+    else:
+        executed_sell = int(trade_data["executed_sell_amount"])
+        sell_price = Fraction(int(trade_data["sell_token_price"]), 10**18)
+        volume = math.floor(executed_sell * sell_price)
+    return volume
 
 def compute_score(trade_data) -> int:
     limit_sell = int(trade_data["limit_sell_amount"])

--- a/mechanism.py
+++ b/mechanism.py
@@ -8,6 +8,7 @@ class Trade:
     id: str
     sell_token: str
     buy_token: str
+    volume: int
     score: int
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,9 +5,11 @@ description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.13"
 dependencies = [
+    "altair>=6.0.0",
     "black>=25.1.0",
     "jupyter>=1.1.1",
     "mypy>=1.15.0",
+    "polars>=1.37.1",
     "psycopg[binary]>=3.2.6",
     "pylint>=3.3.5",
     "pytest>=8.3.5",

--- a/sli_rewards.py
+++ b/sli_rewards.py
@@ -55,9 +55,7 @@ def compute_participation_rates(solutions_batch):
     participation_rates = {solver: nr_orders / total_orders for solver, nr_orders in orders_per_solver.items()}
     return participation_rates
 
-participation_rates = compute_participation_rates(solutions_batch)
-
-def robust_surplus_metric(solutions):
+def robust_surplus_metric(solutions, participation_rates):
     robust_surplus = 0
     all_order_uids = {trade.id for solution in solutions for trade in solution.trades}
     for order_uid in all_order_uids:
@@ -75,66 +73,77 @@ def robust_surplus_metric(solutions):
         robust_surplus += robust_surplus_order
     return robust_surplus
 
-metrics = [surplus_metric, nr_orders_metric, robust_surplus_metric]
+def compute_metrics(solutions_batch):
+    participation_rates = compute_participation_rates(solutions_batch)
+    metrics = [surplus_metric, nr_orders_metric, lambda x: robust_surplus_metric(x, participation_rates)]
+    all_winners_rewards = []
+    all_metrics = []
+    reference_metrics = []
+    single_metrics = []
+    for solutions in solutions_batch:
+        winners, rewards = mechanism.winners_and_rewards(solutions)
+        all_winners_rewards.append((winners, rewards))
+        # all_metrics.append([metric(winners) for metric in metrics])
+        all_metrics.append([metric(solutions) for metric in metrics])
+        reference_metrics.append({})
+        single_metrics.append({})
+        solvers = {solution.solver for solution in solutions}
+        # metrics if solver were removed
+        for solver in solvers:
+            filtered_solutions = [solution for solution in solutions if solution.solver != solver]
+            # reference_winners, _ = mechanism.winners_and_rewards(
+            #     filtered_solutions
+            # )
+            # reference_metrics[-1][solver] = [metric(reference_winners) for metric in metrics]
+            reference_metrics[-1][solver] = [metric(filtered_solutions) for metric in metrics]
+        # metric if only one solver participated
+        for solver in solvers:
+            filtered_solutions = [solution for solution in solutions if solution.solver == solver]
+            # reference_winners, _ = mechanism.winners_and_rewards(
+            #     filtered_solutions
+            # )
+            # single_metrics[-1][solver] = [metric(reference_winners) for metric in metrics]
+            single_metrics[-1][solver] = [metric(filtered_solutions) for metric in metrics]
 
-all_winners_rewards = []
-all_metrics = []
-reference_metrics = []
-single_metrics = []
-for solutions in solutions_batch:
-    winners, rewards = mechanism.winners_and_rewards(solutions)
-    all_winners_rewards.append((winners, rewards))
-    all_metrics.append([metric(winners) for metric in metrics])
-    reference_metrics.append({})
-    single_metrics.append({})
-    solvers = {solution.solver for solution in solutions}
-    # metrics if solver were removed
-    for solver in solvers:
-        filtered_solutions = [solution for solution in solutions if solution.solver != solver]
-        # reference_winners, _ = mechanism.winners_and_rewards(
-        #     filtered_solutions
-        # )
-        # reference_metrics[-1][solver] = [metric(reference_winners) for metric in metrics]
-        reference_metrics[-1][solver] = [metric(filtered_solutions) for metric in metrics]
-    # metric if only one solver participated
-    for solver in solvers:
-        filtered_solutions = [solution for solution in solutions if solution.solver == solver]
-        # reference_winners, _ = mechanism.winners_and_rewards(
-        #     filtered_solutions
-        # )
-        # single_metrics[-1][solver] = [metric(reference_winners) for metric in metrics]
-        single_metrics[-1][solver] = [metric(filtered_solutions) for metric in metrics]
+    # set up polars data frames
+    auction_metrics_df = pl.DataFrame(
+        all_metrics,
+        schema=["surplus", "nr_orders", "robust_surplus"],
+        orient="row",
+    ).with_row_index("index")
+    metric_without_solver_df = pl.DataFrame(
+        [[i, k, v[0], v[1], v[2]] for i, d in enumerate(reference_metrics) for k, v in d.items()],
+        schema=["index", "solver", "surplus", "nr_orders", "robust_surplus"],
+        orient="row",
+    )
+    metric_improvement_df = metric_without_solver_df.join(
+        auction_metrics_df, on="index", suffix="_t2"
+    ).select(
+        "index",
+        "solver",
+        (pl.col("surplus_t2") - pl.col("surplus")).alias("surplus_marginal"),
+        (pl.col("nr_orders_t2") - pl.col("nr_orders")).alias("nr_orders_marginal"),
+        (pl.col("robust_surplus_t2") - pl.col("robust_surplus")).alias("robust_surplus_marginal"),
+    )
+    metric_with_single_solver_df = pl.DataFrame(
+        [[i, k, v[0], v[1], v[2]] for i, d in enumerate(single_metrics) for k, v in d.items()],
+        schema=["index", "solver", "surplus_individual", "nr_orders_individual", "robust_surplus_individual"],
+        orient="row",
+    )
 
-# set up polars data frames
-auction_metrics_df = pl.DataFrame(
-    all_metrics,
-    schema=["surplus", "nr_orders", "robust_surplus"],
-    orient="row",
-).with_row_index("index")
-metric_without_solver_df = pl.DataFrame(
-    [[i, k, v[0], v[1], v[2]] for i, d in enumerate(reference_metrics) for k, v in d.items()],
-    schema=["index", "solver", "surplus", "nr_orders", "robust_surplus"],
-    orient="row",
-)
-metric_improvement_df = metric_without_solver_df.join(
-    auction_metrics_df, on="index", suffix="_t2"
-).select(
-    "index",
-    "solver",
-    (pl.col("surplus_t2") - pl.col("surplus")).alias("surplus_marginal"),
-    (pl.col("nr_orders_t2") - pl.col("nr_orders")).alias("nr_orders_marginal"),
-    (pl.col("robust_surplus_t2") - pl.col("robust_surplus")).alias("robust_surplus_marginal"),
-)
-metric_with_single_solver_df = pl.DataFrame(
-    [[i, k, v[0], v[1], v[2]] for i, d in enumerate(single_metrics) for k, v in d.items()],
-    schema=["index", "solver", "surplus_individual", "nr_orders_individual", "robust_surplus_individual"],
-    orient="row",
-)
+    combined_metrics_df = metric_improvement_df.join(
+        metric_with_single_solver_df, on=["index", "solver"]
+    )
 
-combined_metrics_df = metric_improvement_df.join(
-    metric_with_single_solver_df, on=["index", "solver"]
-).sort(by="surplus_marginal")
+    return combined_metrics_df
 
+
+
+combined_metrics_df = compute_metrics(solutions_batch)
+combined_metrics_df.group_by(pl.col("solver")).sum().sort(by="surplus_marginal", descending=True)
+
+combined_metrics_without_small_orders_df = compute_metrics([[solution for solution in solutions if not (solution.solver == "0xa9d635ef85bc37eb9ff9d6165481ea230ed32392" and sum(trade.volume for trade in solution.trades) < 10**18)] for solutions in solutions_batch])
+combined_metrics_without_small_orders_df.group_by(pl.col("solver")).sum().sort(by="surplus_marginal", descending=True)
 
 # Reshape to long format for grouped bars
 df_long = combined_metrics_df.group_by(pl.col("solver")).sum().unpivot(

--- a/sli_rewards.py
+++ b/sli_rewards.py
@@ -17,6 +17,9 @@ from mechanism import (
 auction_start = 12187189 - 50000
 auction_end = 12187189
 
+# auction_start = 12217089
+# auction_end = 12264319
+
 solutions_batch = fetch_auctions(auction_start, auction_end)
 
 reward_cap_upper = 10**24

--- a/sli_rewards.py
+++ b/sli_rewards.py
@@ -1,0 +1,212 @@
+import altair as alt
+import polars as pl
+
+from data_fetching import fetch_auctions
+
+from mechanism import (
+    FilterRankRewardMechanism,
+    BaselineFilter,
+    DirectedTokenPairs,
+    DirectSelection,
+    SubsetFilteringSelection,
+    ReferenceReward,
+    Solution,
+    Trade,
+)
+
+auction_start = 12187189 - 50000
+auction_end = 12187189
+
+solutions_batch = fetch_auctions(auction_start, auction_end)
+
+reward_cap_upper = 10**24
+reward_cap_lower = 10 * 10**15
+mechanism = FilterRankRewardMechanism(
+    BaselineFilter(),
+    DirectSelection(
+        SubsetFilteringSelection(
+            batch_compatibility=DirectedTokenPairs(), cumulative_filtering=False
+        )
+    ),
+    ReferenceReward(
+        DirectSelection(
+            SubsetFilteringSelection(
+                batch_compatibility=DirectedTokenPairs(),
+                cumulative_filtering=False,
+            )
+        ),
+        reward_cap_upper,
+        reward_cap_lower,
+    ),
+)
+
+def surplus_metric(solutions):
+    winners, _ = mechanism.winners_and_rewards(solutions)
+    return sum(sum(trade.score / 1e18 for trade in winner.trades) for winner in winners)
+
+def nr_orders_metric(solutions):
+    winners, _ = mechanism.winners_and_rewards(solutions)
+    return sum(len(solution.trades) for solution in winners)
+
+def compute_participation_rates(solutions_batch):
+    total_orders = len({trade.id for solutions in solutions_batch for solution in solutions for trade in solution.trades})
+    all_solvers = {solution.solver for solutions in solutions_batch for solution in solutions}
+    orders_per_solver = {solver: len({trade.id for solutions in solutions_batch for solution in solutions for trade in solution.trades if solution.solver == solver}) for solver in all_solvers}
+    participation_rates = {solver: nr_orders / total_orders for solver, nr_orders in orders_per_solver.items()}
+    return participation_rates
+
+participation_rates = compute_participation_rates(solutions_batch)
+
+def robust_surplus_metric(solutions):
+    robust_surplus = 0
+    all_order_uids = {trade.id for solution in solutions for trade in solution.trades}
+    for order_uid in all_order_uids:
+        order_scores = [(solution.solver, trade.score) for solution in solutions for trade in solution.trades if trade.id == order_uid]
+        # sorting
+        order_scores = sorted(order_scores, key=lambda x: x[1], reverse=True)
+        # removing duplicates
+        solvers_seen = set()
+        order_scores = [x for x in order_scores if not (x[0] in solvers_seen or solvers_seen.add(x[0]))]
+        robust_surplus_order = 0.0
+        remaining_probability = 1.
+        for solver, score in order_scores:
+            robust_surplus_order += remaining_probability * participation_rates[solver] * score / 1e18
+            remaining_probability *= 1 - participation_rates[solver]
+        robust_surplus += robust_surplus_order
+    return robust_surplus
+
+metrics = [surplus_metric, nr_orders_metric, robust_surplus_metric]
+
+all_winners_rewards = []
+all_metrics = []
+reference_metrics = []
+single_metrics = []
+for solutions in solutions_batch:
+    winners, rewards = mechanism.winners_and_rewards(solutions)
+    all_winners_rewards.append((winners, rewards))
+    all_metrics.append([metric(winners) for metric in metrics])
+    reference_metrics.append({})
+    single_metrics.append({})
+    solvers = {solution.solver for solution in solutions}
+    # metrics if solver were removed
+    for solver in solvers:
+        filtered_solutions = [solution for solution in solutions if solution.solver != solver]
+        # reference_winners, _ = mechanism.winners_and_rewards(
+        #     filtered_solutions
+        # )
+        # reference_metrics[-1][solver] = [metric(reference_winners) for metric in metrics]
+        reference_metrics[-1][solver] = [metric(filtered_solutions) for metric in metrics]
+    # metric if only one solver participated
+    for solver in solvers:
+        filtered_solutions = [solution for solution in solutions if solution.solver == solver]
+        # reference_winners, _ = mechanism.winners_and_rewards(
+        #     filtered_solutions
+        # )
+        # single_metrics[-1][solver] = [metric(reference_winners) for metric in metrics]
+        single_metrics[-1][solver] = [metric(filtered_solutions) for metric in metrics]
+
+# set up polars data frames
+auction_metrics_df = pl.DataFrame(
+    all_metrics,
+    schema=["surplus", "nr_orders", "robust_surplus"],
+    orient="row",
+).with_row_index("index")
+metric_without_solver_df = pl.DataFrame(
+    [[i, k, v[0], v[1], v[2]] for i, d in enumerate(reference_metrics) for k, v in d.items()],
+    schema=["index", "solver", "surplus", "nr_orders", "robust_surplus"],
+    orient="row",
+)
+metric_improvement_df = metric_without_solver_df.join(
+    auction_metrics_df, on="index", suffix="_t2"
+).select(
+    "index",
+    "solver",
+    (pl.col("surplus_t2") - pl.col("surplus")).alias("surplus_marginal"),
+    (pl.col("nr_orders_t2") - pl.col("nr_orders")).alias("nr_orders_marginal"),
+    (pl.col("robust_surplus_t2") - pl.col("robust_surplus")).alias("robust_surplus_marginal"),
+)
+metric_with_single_solver_df = pl.DataFrame(
+    [[i, k, v[0], v[1], v[2]] for i, d in enumerate(single_metrics) for k, v in d.items()],
+    schema=["index", "solver", "surplus_individual", "nr_orders_individual", "robust_surplus_individual"],
+    orient="row",
+)
+
+combined_metrics_df = metric_improvement_df.join(
+    metric_with_single_solver_df, on=["index", "solver"]
+).sort(by="surplus_marginal")
+
+
+# Reshape to long format for grouped bars
+df_long = combined_metrics_df.group_by(pl.col("solver")).sum().unpivot(
+    index="solver",
+    on=["surplus_marginal", "nr_orders_marginal", "robust_surplus_marginal", "surplus_individual", "nr_orders_individual", "robust_surplus_individual"],
+    variable_name="metric",
+    value_name="value",
+).with_columns(
+    (pl.col("value") / pl.col("value").sum().over("metric"))
+    .alias("value")
+)
+
+solver_order = (
+    df_long.filter(pl.col("metric") == "surplus_marginal")
+    .sort("value", descending=True)
+    .get_column("solver")
+    .to_list()
+)
+
+chart = df_long.plot.bar(
+    x=alt.X("solver", sort=solver_order),
+    y="value",
+    color="metric",
+    xOffset="metric",
+).properties(
+    width="container",
+    height=400,
+)
+
+chart.save("chart.html")
+
+## test case
+
+# participation_rates = {"solver 1": 0.9, "solver 2": 0.8, "solver 3": 0.95}
+# solutions = [
+#     Solution(
+#         id="solution 1",
+#         solver="solver 1",
+#         score=10,
+#         trades=[Trade(
+#             id="order 1",
+#             sell_token="A",
+#             buy_token="B",
+#             score=10,
+#         )],
+#     ),
+#     Solution(
+#         id="solution 2",
+#         solver="solver 2",
+#         score=10,
+#         trades=[Trade(
+#             id="order 1",
+#             sell_token="A",
+#             buy_token="B",
+#             score=9,
+#         )],
+#     ),
+#     Solution(
+#         id="solution 3",
+#         solver="solver 3",
+#         score=10,
+#         trades=[Trade(
+#             id="order 1",
+#             sell_token="A",
+#             buy_token="B",
+#             score=8,
+#         )],
+#     ),
+# ]
+
+# robust_surplus_metric(solutions)
+
+# robust_surplus_metric(solutions) - robust_surplus_metric([solution for solution in solutions if solution.solver != "solver 1"])
+# robust_surplus_metric(solutions) - robust_surplus_metric([solution for solution in solutions if solution.solver != "solver 2"])
+# # robust_surplus_metric(solutions) - robust_surplus_metric([solution for solution in solutions if solution.solver != "solver 3"])

--- a/uv.lock
+++ b/uv.lock
@@ -2,6 +2,22 @@ version = 1
 requires-python = ">=3.13"
 
 [[package]]
+name = "altair"
+version = "6.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jinja2" },
+    { name = "jsonschema" },
+    { name = "narwhals" },
+    { name = "packaging" },
+    { name = "typing-extensions", marker = "python_full_version < '3.15'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f7/c0/184a89bd5feba14ff3c41cfaf1dd8a82c05f5ceedbc92145e17042eb08a4/altair-6.0.0.tar.gz", hash = "sha256:614bf5ecbe2337347b590afb111929aa9c16c9527c4887d96c9bc7f6640756b4", size = 763834 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/db/33/ef2f2409450ef6daa61459d5de5c08128e7d3edb773fefd0a324d1310238/altair-6.0.0-py3-none-any.whl", hash = "sha256:09ae95b53d5fe5b16987dccc785a7af8588f2dca50de1e7a156efa8a461515f8", size = 795410 },
+]
+
+[[package]]
 name = "anyio"
 version = "4.8.0"
 source = { registry = "https://pypi.org/simple" }
@@ -243,9 +259,11 @@ name = "comb-auctions"
 version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
+    { name = "altair" },
     { name = "black" },
     { name = "jupyter" },
     { name = "mypy" },
+    { name = "polars" },
     { name = "psycopg", extra = ["binary"] },
     { name = "pylint" },
     { name = "pytest" },
@@ -256,9 +274,11 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
+    { name = "altair", specifier = ">=6.0.0" },
     { name = "black", specifier = ">=25.1.0" },
     { name = "jupyter", specifier = ">=1.1.1" },
     { name = "mypy", specifier = ">=1.15.0" },
+    { name = "polars", specifier = ">=1.37.1" },
     { name = "psycopg", extras = ["binary"], specifier = ">=3.2.6" },
     { name = "pylint", specifier = ">=3.3.5" },
     { name = "pytest", specifier = ">=8.3.5" },
@@ -887,6 +907,15 @@ wheels = [
 ]
 
 [[package]]
+name = "narwhals"
+version = "2.15.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/47/6d/b57c64e5038a8cf071bce391bb11551657a74558877ac961e7fa905ece27/narwhals-2.15.0.tar.gz", hash = "sha256:a9585975b99d95084268445a1fdd881311fa26ef1caa18020d959d5b2ff9a965", size = 603479 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3d/2e/cf2ffeb386ac3763526151163ad7da9f1b586aac96d2b4f7de1eaebf0c61/narwhals-2.15.0-py3-none-any.whl", hash = "sha256:cbfe21ca19d260d9fd67f995ec75c44592d1f106933b03ddd375df7ac841f9d6", size = 432856 },
+]
+
+[[package]]
 name = "nbclient"
 version = "0.10.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1051,6 +1080,34 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/96/2d/02d4312c973c6050a18b314a5ad0b3210edb65a906f868e31c111dede4a6/pluggy-1.5.0.tar.gz", hash = "sha256:2cffa88e94fdc978c4c574f15f9e59b7f4201d439195c3715ca9e2486f1d0cf1", size = 67955 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/88/5f/e351af9a41f866ac3f1fac4ca0613908d9a41741cfcf2228f4ad853b697d/pluggy-1.5.0-py3-none-any.whl", hash = "sha256:44e1ad92c8ca002de6377e165f3e0f1be63266ab4d554740532335b9d75ea669", size = 20556 },
+]
+
+[[package]]
+name = "polars"
+version = "1.37.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "polars-runtime-32" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/84/ae/dfebf31b9988c20998140b54d5b521f64ce08879f2c13d9b4d44d7c87e32/polars-1.37.1.tar.gz", hash = "sha256:0309e2a4633e712513401964b4d95452f124ceabf7aec6db50affb9ced4a274e", size = 715572 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/08/75/ec73e38812bca7c2240aff481b9ddff20d1ad2f10dee4b3353f5eeaacdab/polars-1.37.1-py3-none-any.whl", hash = "sha256:377fed8939a2f1223c1563cfabdc7b4a3d6ff846efa1f2ddeb8644fafd9b1aff", size = 805749 },
+]
+
+[[package]]
+name = "polars-runtime-32"
+version = "1.37.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/40/0b/addabe5e8d28a5a4c9887a08907be7ddc3fce892dc38f37d14b055438a57/polars_runtime_32-1.37.1.tar.gz", hash = "sha256:68779d4a691da20a5eb767d74165a8f80a2bdfbde4b54acf59af43f7fa028d8f", size = 2818945 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/a2/e828ea9f845796de02d923edb790e408ca0b560cd68dbd74bb99a1b3c461/polars_runtime_32-1.37.1-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:0b8d4d73ea9977d3731927740e59d814647c5198bdbe359bcf6a8bfce2e79771", size = 43499912 },
+    { url = "https://files.pythonhosted.org/packages/7e/46/81b71b7aa9e3703ee6e4ef1f69a87e40f58ea7c99212bf49a95071e99c8c/polars_runtime_32-1.37.1-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:c682bf83f5f352e5e02f5c16c652c48ca40442f07b236f30662b22217320ce76", size = 39695707 },
+    { url = "https://files.pythonhosted.org/packages/81/2e/20009d1fde7ee919e24040f5c87cb9d0e4f8e3f109b74ba06bc10c02459c/polars_runtime_32-1.37.1-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:fc82b5bbe70ca1a4b764eed1419f6336752d6ba9fc1245388d7f8b12438afa2c", size = 41467034 },
+    { url = "https://files.pythonhosted.org/packages/eb/21/9b55bea940524324625b1e8fd96233290303eb1bf2c23b54573487bbbc25/polars_runtime_32-1.37.1-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a8362d11ac5193b994c7e9048ffe22ccfb976699cfbf6e128ce0302e06728894", size = 45142711 },
+    { url = "https://files.pythonhosted.org/packages/8c/25/c5f64461aeccdac6834a89f826d051ccd3b4ce204075e562c87a06ed2619/polars_runtime_32-1.37.1-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:04f5d5a2f013dca7391b7d8e7672fa6d37573a87f1d45d3dd5f0d9b5565a4b0f", size = 41638564 },
+    { url = "https://files.pythonhosted.org/packages/35/af/509d3cf6c45e764ccf856beaae26fc34352f16f10f94a7839b1042920a73/polars_runtime_32-1.37.1-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:fbfde7c0ca8209eeaed546e4a32cca1319189aa61c5f0f9a2b4494262bd0c689", size = 44721136 },
+    { url = "https://files.pythonhosted.org/packages/af/d1/5c0a83a625f72beef59394bebc57d12637997632a4f9d3ab2ffc2cc62bbf/polars_runtime_32-1.37.1-cp310-abi3-win_amd64.whl", hash = "sha256:da3d3642ae944e18dd17109d2a3036cb94ce50e5495c5023c77b1599d4c861bc", size = 44948288 },
+    { url = "https://files.pythonhosted.org/packages/10/f3/061bb702465904b6502f7c9081daee34b09ccbaa4f8c94cf43a2a3b6dd6f/polars_runtime_32-1.37.1-cp310-abi3-win_arm64.whl", hash = "sha256:55f2c4847a8d2e267612f564de7b753a4bde3902eaabe7b436a0a4abf75949a0", size = 41001914 },
 ]
 
 [[package]]


### PR DESCRIPTION
Metrics checked:

* Surplus provided
* Number of orders executed
* Robust score, an expected score taking into account participation rates of solvers

These metrics are turned into a marginal and individual contribution.
* marginal: how much would a metric get worse when removing a solver
* individual: what would a metric look like if only one solver were participating

Run
```
uv run python sli_rewards.py
```
to generate a `chart.html` file with a figure of the form
<img width="2397" height="1417" alt="image" src="https://github.com/user-attachments/assets/caf33404-6d1b-4b99-91fb-7fe6f807b8d1" />
